### PR TITLE
SHE-5: ComScore Integration for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ ionic plugin add phonegap-plugin-push --variable SENDER_ID="54566305933"
 
 ionic plugin add cordova-plugin-network-information
 
+ionic plugin add https://github.com/fourmisolutions/cordova-comscore-plugin
+
 If contain error like this, follow this step - http://stackoverflow.com/questions/33475178/cordova-fails-to-build-on-android-gcm-dependency
 * What went wrong:
 A problem occurred configuring root project 'android'.

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "ionic-plugin-keyboard",
     "cordova-plugin-network-information",
     "cordova-plugin-compat",
-    "phonegap-plugin-push  --variable SENDER_ID=167400319609",
     "https://github.com/tiltshiftfocus/cordova-plugin-cache.git",
-    "cordova-plugin-app-preferences"
+    "cordova-plugin-app-preferences",
+    "https://github.com/fourmisolutions/cordova-comscore-plugin.git",
+    "phonegap-plugin-push  --variable SENDER_ID=167400319609"
     
   ],
   "cordovaPlatforms": [

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -93,6 +93,21 @@
             //trying to clear cache 
             ePaperService.clearCache();
             
+            /* ComScore SDK v5.X start */
+            // TODO: only for android, ios not yet ready
+        	
+        	ComScorePlugin.initClient("24608202", "82a44e8c84c174abac3cfdbcb2050ced");
+        	
+        	$ionicPlatform.on('pause', function() {
+        	    ComScorePlugin.notifyExitForeground();
+        	});
+
+        	$ionicPlatform.on('resume', function() {
+                ComScorePlugin.notifyEnterForeground();
+        	});
+
+        	/* ComScore SDK v5.X end */
+            
         });
     })
 


### PR DESCRIPTION
Added ComScore integration for Android platform.

For testing, please install the ComScore plugin to the ionic project first:
```
$ ionic plugin add https://github.com/fourmisolutions/cordova-comscore-plugin
```

Refer to "Chapter 3: Test Your Implementation" in the attached ComScore implementation specifications PDF file to perform the recommended test.

[comScoreImplementationSpecs-Android.pdf](https://github.com/fourmisolutions/epaper/files/1011451/comScoreImplementationSpecs-Android.pdf)
