### PR TITLE
SHE-19 - Disable range because it caused PDF to load forever

### DIFF
--- a/www/js/directives.js
+++ b/www/js/directives.js
@@ -147,6 +147,7 @@
             container.css('height', $window.innerHeight * 0.8 + 'px');
             var zoomTime = 0;
             PDFJS.disableWorker = true;
+            PDFJS.disableRange = true;
 
             scope.pageFit = function () {
                 zoomTime = 0;


### PR DESCRIPTION
Problem: Browser compatibility issue to load the pdf
Solution: It is related to the browser loading the pdf - https://github.com/mozilla/pdf.js/issues/5405#issuecomment-252546051